### PR TITLE
raise custom exception to clarify FileNotFoundError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
     - name: Check black formatting
       python: 3.7
       env: TOXENV=black
-    - name: Check flake8 on Python 2
-      python: 2.7
-      env: TOXENV=flake8
     - name: Check flake8 on Python 3
       python: 3.7
       env: TOXENV=flake8

--- a/faculty_distributed/manager.py
+++ b/faculty_distributed/manager.py
@@ -8,6 +8,14 @@ import tempfile
 from faculty import client
 
 
+class JobOutputNotFoundError(Exception):
+    """Raised when the output of a job has not been saved. This error is likely
+    to have been raised due to a failed job.
+    """
+
+    pass
+
+
 class FacultyJobExecutor:
     """
     Run generic python function in parallel on Faculty Jobs
@@ -107,11 +115,18 @@ class FacultyJobExecutor:
         """
         out = []
         for i in range(len(args_sequence)):
-            with open(
-                os.path.join(self.tmpdir, "output/out_{}.pkl".format(i)), "rb"
-            ) as f:
-                out.append(cloudpickle.load(f))
-
+            filepath = os.path.join(self.tmpdir, "output/out_{}.pkl".format(i))
+            try:
+                with open(filepath, "rb",) as f:
+                    out.append(cloudpickle.load(f))
+            except FileNotFoundError:
+                raise JobOutputNotFoundError(
+                    "No such file: '{}'. This error is likely to have been "
+                    "raised due to a failed job. Check the Jobs history for "
+                    "further details.".format(
+                        filepath
+                    )
+                )
         return out
 
     def _make_dirs(self):

--- a/faculty_distributed/manager.py
+++ b/faculty_distributed/manager.py
@@ -123,9 +123,7 @@ class FacultyJobExecutor:
                 raise JobOutputNotFoundError(
                     "No such file: '{}'. This error is likely to have been "
                     "raised due to a failed job. Check the Jobs history for "
-                    "further details.".format(
-                        filepath
-                    )
+                    "further details.".format(filepath)
                 )
         return out
 

--- a/faculty_distributed/manager.py
+++ b/faculty_distributed/manager.py
@@ -119,15 +119,12 @@ class FacultyJobExecutor:
             try:
                 with open(filepath, "rb",) as f:
                     out.append(cloudpickle.load(f))
-            except OSError as e:
-                if isinstance(e, FileNotFoundError):
-                    raise JobOutputNotFoundError(
-                        "No such file: '{}'. This error is likely to have "
-                        "been raised due to a failed job. Check the Jobs "
-                        "history for further details.".format(filepath)
-                    )
-                else:
-                    raise e
+            except FileNotFoundError:
+                raise JobOutputNotFoundError(
+                    "No such file: '{}'. This error is likely to have been "
+                    "raised due to a failed job. Check the Jobs history for "
+                    "further details.".format(filepath)
+                )
         return out
 
     def _make_dirs(self):

--- a/faculty_distributed/manager.py
+++ b/faculty_distributed/manager.py
@@ -119,12 +119,15 @@ class FacultyJobExecutor:
             try:
                 with open(filepath, "rb",) as f:
                     out.append(cloudpickle.load(f))
-            except FileNotFoundError:
-                raise JobOutputNotFoundError(
-                    "No such file: '{}'. This error is likely to have been "
-                    "raised due to a failed job. Check the Jobs history for "
-                    "further details.".format(filepath)
-                )
+            except OSError as e:
+                if isinstance(e, FileNotFoundError):
+                    raise JobOutputNotFoundError(
+                        "No such file: '{}'. This error is likely to have "
+                        "been raised due to a failed job. Check the Jobs "
+                        "history for further details.".format(filepath)
+                    )
+                else:
+                    raise e
         return out
 
     def _make_dirs(self):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ commands =
 [testenv:black]
 skip_install = True
 deps =
-    black==19.3b0
+    black==19.10b0
 commands =
     black {posargs:--check .}


### PR DESCRIPTION
Raise custom exception to clarify FileNotFoundError that occurs when jobs fail.